### PR TITLE
Hinding the major ticks

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,8 @@ circleColor = '{CIRCLE_COLOR}'
 textColor = '{TEXT_COLOR}'
 
 set grid
-
+set tics scale 0
+            
 unset key
 
 set multiplot layout 1,1


### PR DESCRIPTION
This change looking for to improve the readability of y axis labels.

Below the pictures show a situation.

- **new.pdf** is without major ticks
- **old.pdf** contains major ticks

[new.pdf](https://github.com/thiagodnf/bubble-chart-for-gnuplot/files/1942961/out.pdf)
[old.pdf](https://github.com/thiagodnf/bubble-chart-for-gnuplot/files/1942960/out1.pdf)
